### PR TITLE
Bump usb dependency to 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"usb"
   ],
   "dependencies": {
-     "usb": "~1.2.0"
+     "usb": "~1.6.2"
    },
 	 "engines": { 
   	"node": ">=6.x" 


### PR DESCRIPTION
1.2.0 no longer has a valid release to download for arm architecture.